### PR TITLE
v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ By using this script, you acknowledge that:
 
 ## Recent Updates
 
+### Version 1.0.3 (June 13, 2025)
+
+- Fixed ZFS cachefile property setting (using zpool set instead of zfs set)
+- Fixed an issue that caused errors during boot configuration
+
 ### Version 1.0.2 (June 13, 2025)
 
 - Added interactive hostname configuration with FQDN support
@@ -152,6 +157,10 @@ The installer automates the following processes:
 - **Variable Files**: Separate datasets for `/var` subdirectories
 - **Performance**: Tuned compression and other ZFS properties for best performance
 - **Boot Support**: Proper GRUB integration for ZFS boot
+
+## Known Issues
+
+- Install script does not seem to be able to unmount properly in the live installer. Rebooting, worked as expected though so ¯\_(ツ)_/¯
 
 ## Troubleshooting
 

--- a/deb-12-zfs-install.sh
+++ b/deb-12-zfs-install.sh
@@ -44,7 +44,7 @@ for arg in "$@"; do
             show_help
             ;;
         --version)
-            echo "Debian 12 ZFS Root Installer v1.0.2"
+            echo "Debian 12 ZFS Root Installer v1.0.3"
             exit 0
             ;;
         --test)
@@ -703,8 +703,7 @@ chroot /target /bin/systemctl enable zfs-import-bpool.service
 # Configure ZFS mount order
 echo "Configuring ZFS mount order for boot..."
 chroot /target mkdir -p /etc/zfs/zfs-list.cache
-chroot /target zfs set cachefile=/etc/zfs/zpool.cache $BPOOL
-chroot /target zfs set cachefile=/etc/zfs/zpool.cache $ZPOOL
+# Setting cachefile is only valid for pools, not datasets
 chroot /target zpool set cachefile=/etc/zfs/zpool.cache $BPOOL
 chroot /target zpool set cachefile=/etc/zfs/zpool.cache $ZPOOL
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `deb-12-zfs-install.sh` files to fix bugs, improve documentation, and update the version number to `v1.0.3`. The most important changes address ZFS cachefile property settings, boot configuration errors, and known issues with the install script.

### Bug Fixes:

* [`deb-12-zfs-install.sh`](diffhunk://#diff-916b35ecb2da40613e3f9afe65d223004105a395a3c59c44de067090f7f246d7L706-R706): Corrected ZFS cachefile property handling by using `zpool set` instead of `zfs set`, as the cachefile setting is only valid for pools, not datasets.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20-R24): Documented fixes for ZFS cachefile property settings and boot configuration errors in the changelog for version `1.0.3`.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R164): Added a "Known Issues" section to highlight that the install script may fail to unmount properly in the live installer, with a workaround provided.

### Version Update:

* [`deb-12-zfs-install.sh`](diffhunk://#diff-916b35ecb2da40613e3f9afe65d223004105a395a3c59c44de067090f7f246d7L47-R47): Updated the version number displayed by the `--version` flag to `v1.0.3`.